### PR TITLE
Fix bug where >2 links causes duplicates on page re-rendering

### DIFF
--- a/src/components/task.js
+++ b/src/components/task.js
@@ -84,9 +84,9 @@ class Task extends Component {
             )}
             {task.links && (
               <ul className="fa-ul">
-                {task.links.map((link, i) => {
+                {task.links.map((link) => {
                   return (
-                    <li key={link}>
+                    <li>
                       <a href={link.path} target="_blank">
                         <i className={TypeIcon(link.type)} aria-hidden="true" />
                         {link.text}


### PR DESCRIPTION
- Prior to this fix, any task object that had greater-than 2 links would duplicate n-1 of those links every time the page rendered. 
I made an assumption that it had something to do with Preact duplicating based on passing the entire `link` object to `key=` and it seems to work simply by removing the `key=` attribute altogether.
- Also removed the unused `i` parameter